### PR TITLE
Minor cleanup and type fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ crew-assistant/
 │   ├── planner.py
 │   ├── dev.py
 │   └── commander.py
-├── tasks/
-│   └── curriculum_task.py
 ├── crew_agents.py        # Entrypoint script
+├── crew_assistant/
+│   ├── dynamic_crew.py   # Sample crew using dynamic agent discovery
+│   └── wrap_crew_run.py  # CLI wrapper with UX mode
 ├── .env                  # API config (excluded from repo)
 ├── requirements.txt      # Python dependencies
 ```

--- a/core/context_engine/context_types.py
+++ b/core/context_engine/context_types.py
@@ -1,8 +1,11 @@
 from dataclasses import dataclass
 from typing import Optional
 
+
 @dataclass
 class ContextEntry:
+    """Single memory entry used by the context engine."""
+
     timestamp: str
     agent: str
     input_summary: str

--- a/crew_assistant/dynamic_crew.py
+++ b/crew_assistant/dynamic_crew.py
@@ -1,4 +1,4 @@
-# === FILE: crew_agents.py ===
+# === FILE: dynamic_crew.py ===
 
 from crewai import Crew, Task
 from core.agent_registry import discover_agents

--- a/crew_assistant/test_context.py
+++ b/crew_assistant/test_context.py
@@ -1,12 +1,14 @@
-# === FILE: test_context.py ===
+"""Lightweight demo for the MemoryStore class."""
+
 from core.context_engine import MemoryStore
 
 store = MemoryStore()
-store.save_entry(
+store.save(
     agent="DevAgent",
     input_summary="Build memory_store with context saving and loading",
-    output_summary="Successfully created and tested save/load"
+    output_summary="Successfully created and tested save/load",
 )
+
 print("🧠 Last memory entries:")
-for entry in store.latest(2):
+for entry in store.recent(count=2):
     print(entry)


### PR DESCRIPTION
## Summary
- clean up memory store example and context types
- tidy wrap_crew_run logging and fallback logic
- rename dynamic crew example to avoid module collision
- update architecture diagram in README

## Testing
- `ruff check .`
- `mypy --ignore-missing-imports .`
- `PYTHONPATH=. python crew_assistant/test_context.py`


------
https://chatgpt.com/codex/tasks/task_e_68564e13d760832aa802ed801dee8aaa